### PR TITLE
Update routes.xml

### DIFF
--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -11,7 +11,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
 
     <router id="admin">
-        <route id="adminhtml" frontName="downloadable">
+        <route id="downloadable" frontName="downloadable">
             <module name="LizardMedia_ProductAttachment" before="Magento_Backend" />
         </route>
     </router>


### PR DESCRIPTION
I am proposing this change because id adminhtml is used by the entire M2 administration. That is why there are 404 on the M2 admin dashboard and it only works as /backend-url/downloadable/dashboard seen here: https://github.com/lizardmedia/product-attachments-magento2/issues/14