### PR TITLE
File upload URL pointing at OLD adminhtml

### DIFF
--- a/Ui/DataProvider/Product/Form/Modifier/Attachments.php
+++ b/Ui/DataProvider/Product/Form/Modifier/Attachments.php
@@ -272,7 +272,7 @@ class Attachments extends AbstractModifier
             'fileInputName' => 'attachments',
             'uploaderConfig' => [
                 'url' => $this->urlBuilder->addSessionParam()->getUrl(
-                    'adminhtml/attachment_file/upload',
+                    'downloadable/attachment_file/upload',
                     [Attachment::ATTACHMENT_TYPE => 'attachments', '_secure' => true]
                 ),
             ],


### PR DESCRIPTION
File upload URL was still pointing at OLD adminhtml URL resulting in 404 in admin product backend. This change fixes that for good.